### PR TITLE
[HOTFIX] segmentation fault occurs in destructor of PythonProcess

### DIFF
--- a/src/plugin/JupyterPlugin.cpp
+++ b/src/plugin/JupyterPlugin.cpp
@@ -26,7 +26,7 @@ JupyterPlugin::JupyterPlugin()
 JupyterPlugin::~JupyterPlugin()
 {
     if (!!impl) {
-        delete impl;
+        // delete impl; //
     }
 }
 #ifndef EXT_BUNDLE


### PR DESCRIPTION
HOTFIX for https://github.com/IRSL-tut/irsl_docker/issues/8

Just removing the destructor for python objects in c++,
it just avoids to occur seg-fault.